### PR TITLE
Add hybrid graphics mode (#261)

### DIFF
--- a/changes/hybrid-graphics-mode.md
+++ b/changes/hybrid-graphics-mode.md
@@ -1,0 +1,1 @@
+Added a hybrid mode that uses text for creatures and items but graphical tiles for everything else.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -351,9 +351,9 @@ short actionMenu(short x, boolean playingBack) {
 
         if (hasGraphics) {
             if (KEYBOARD_LABELS) {
-                sprintf(buttons[buttonCount].text, "  %sG: %s[%s] Enable graphics  ", yellowColorEscape, whiteColorEscape, graphicsEnabled ? "X" : " ");
+                sprintf(buttons[buttonCount].text, "  %sG: %s[%c] Enable graphics  ", yellowColorEscape, whiteColorEscape, " X~"[graphicsMode]);
             } else {
-                sprintf(buttons[buttonCount].text, "  [%s] Enable graphics  ",   graphicsEnabled ? "X" : " ");
+                sprintf(buttons[buttonCount].text, "  [%c] Enable graphics  ",   " X~"[graphicsMode]);
             }
             buttons[buttonCount].hotkey[0] = GRAPHICS_KEY;
             takeActionOurselves[buttonCount] = true;
@@ -2676,13 +2676,23 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             break;
         case GRAPHICS_KEY:
             if (hasGraphics) {
-                graphicsEnabled = setGraphicsEnabled(!graphicsEnabled);
-                if (graphicsEnabled) {
-                    messageWithColor(KEYBOARD_LABELS ? "Enabled graphical tiles. Press 'G' again to disable." : "Enable graphical tiles.",
-                                    &teal, false);
-                } else {
-                    messageWithColor(KEYBOARD_LABELS ? "Disabled graphical tiles. Press 'G' again to enable." : "Disabled graphical tiles.",
-                                    &teal, false);
+                graphicsMode = setGraphicsMode((graphicsMode + 1) % 3);
+                switch (graphicsMode) {
+                    case TEXT_GRAPHICS:
+                        messageWithColor(KEYBOARD_LABELS
+                            ? "Switched to text mode. Press 'G' again to enable tiles."
+                            : "Switched to text mode.", &teal, false);
+                        break;
+                    case TILES_GRAPHICS:
+                        messageWithColor(KEYBOARD_LABELS
+                            ? "Switched to graphical tiles. Press 'G' again to enable hybrid mode."
+                            : "Switched to graphical tiles.", &teal, false);
+                        break;
+                    case HYBRID_GRAPHICS:
+                        messageWithColor(KEYBOARD_LABELS
+                            ? "Switched to hybrid mode. Press 'G' again to disable tiles."
+                            : "Switched to hybrid mode.", &teal, false);
+                        break;
                 }
             }
             break;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1015,13 +1015,23 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                 return true;
             case GRAPHICS_KEY:
                 if (hasGraphics) {
-                    graphicsEnabled = setGraphicsEnabled(!graphicsEnabled);
-                    if (graphicsEnabled) {
-                        messageWithColor(KEYBOARD_LABELS ? "Enabled graphical tiles. Press 'G' again to disable." : "Enable graphical tiles.",
-                                        &teal, false);
-                    } else {
-                        messageWithColor(KEYBOARD_LABELS ? "Disabled graphical tiles. Press 'G' again to enable." : "Disabled graphical tiles.",
-                                        &teal, false);
+                    graphicsMode = setGraphicsMode((graphicsMode + 1) % 3);
+                    switch (graphicsMode) {
+                        case TEXT_GRAPHICS:
+                            messageWithColor(KEYBOARD_LABELS
+                                ? "Switched to text mode. Press 'G' again to enable tiles."
+                                : "Switched to text mode.", &teal, false);
+                            break;
+                        case TILES_GRAPHICS:
+                            messageWithColor(KEYBOARD_LABELS
+                                ? "Switched to graphical tiles. Press 'G' again to enable hybrid mode."
+                                : "Switched to graphical tiles.", &teal, false);
+                            break;
+                        case HYBRID_GRAPHICS:
+                            messageWithColor(KEYBOARD_LABELS
+                                ? "Switched to hybrid mode. Press 'G' again to disable tiles."
+                                : "Switched to hybrid mode.", &teal, false);
+                            break;
                     }
                 }
                 return true;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -301,6 +301,12 @@ enum displayGlyph {
     G_ORB_ALTAR
 };
 
+enum graphicsModes {
+    TEXT_GRAPHICS,
+    TILES_GRAPHICS,
+    HYBRID_GRAPHICS, // text for items and creatures, tiles for environment
+};
+
 enum eventTypes {
     KEYSTROKE,
     MOUSE_UP,
@@ -2604,7 +2610,7 @@ typedef struct buttonState {
 
 extern boolean serverMode;
 extern boolean hasGraphics;
-extern boolean graphicsEnabled;
+extern enum graphicsModes graphicsMode;
 
 #if defined __cplusplus
 extern "C" {
@@ -2686,7 +2692,7 @@ extern "C" {
     void nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance);
     void notifyEvent(short eventId, int data1, int data2, const char *str1, const char *str2);
     boolean takeScreenshot();
-    boolean setGraphicsEnabled(boolean);
+    enum graphicsModes setGraphicsMode(enum graphicsModes mode);
     boolean controlKeyIsDown();
     boolean shiftKeyIsDown();
     short getHighScoresList(rogueHighScoresEntry returnList[HIGH_SCORES_COUNT]);

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -11,7 +11,7 @@ struct brogueConsole currentConsole;
 char dataDirectory[BROGUE_FILENAME_MAX] = STRINGIFY(DATADIR);
 boolean serverMode = false;
 boolean hasGraphics = false;
-boolean graphicsEnabled = false;
+enum graphicsModes graphicsMode = TEXT_GRAPHICS;
 boolean isCsvFormat = false;
 
 static void printCommandlineHelp() {
@@ -29,6 +29,7 @@ static void printCommandlineHelp() {
 #ifdef BROGUE_SDL
     "--size N                   starts the game at font size N (1 to 20)\n"
     "--graphics     -G          enable graphical tiles\n"
+    "--hybrid       -H          enable hybrid graphics\n"
     "--full-screen  -F          enable full screen\n"
     "--no-gpu                   disable hardware-accelerated graphics and HiDPI\n"
 #endif
@@ -94,7 +95,7 @@ int main(int argc, char *argv[])
     rogue.displayAggroRangeMode = false;
     rogue.trueColorMode = false;
 
-    boolean initialGraphics = false;
+    enum graphicsModes initialGraphics = TEXT_GRAPHICS;
 
     int i;
     for (i = 1; i < argc; i++) {
@@ -186,7 +187,12 @@ int main(int argc, char *argv[])
         }
 
         if (strcmp(argv[i], "-G") == 0 || strcmp(argv[i], "--graphics") == 0) {
-            initialGraphics = true;  // we call setGraphicsEnabled later
+            initialGraphics = TILES_GRAPHICS;  // we call setGraphicsMode later
+            continue;
+        }
+
+        if (strcmp(argv[i], "-H") == 0 || strcmp(argv[i], "--hybrid") == 0) {
+            initialGraphics = HYBRID_GRAPHICS;  // we call setGraphicsMode later
             continue;
         }
 
@@ -270,10 +276,10 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    hasGraphics = (currentConsole.setGraphicsEnabled != NULL);
+    hasGraphics = (currentConsole.setGraphicsMode != NULL);
     // Now actually set graphics. We do this to ensure there is exactly one
     // call, whether true or false
-    graphicsEnabled = setGraphicsEnabled(initialGraphics);
+    graphicsMode = setGraphicsMode(initialGraphics);
 
     loadKeymap();
     currentConsole.gameLoop();

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -82,13 +82,14 @@ struct brogueConsole {
     is called when the user changes the option in-game. It is also called at the
     very start of the program, even before .gameLoop, to set the initial value.
     */
-    boolean (*setGraphicsEnabled)(boolean);
+    enum graphicsModes (*setGraphicsMode)(enum graphicsModes mode);
 };
 
 // defined in platform
 void loadKeymap();
 void dumpScores();
 unsigned int glyphToUnicode(enum displayGlyph glyph);
+boolean isEnvironmentGlyph(enum displayGlyph glyph);
 
 #ifdef BROGUE_SDL
 extern struct brogueConsole sdlConsole;

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -185,6 +185,39 @@ unsigned int glyphToUnicode(enum displayGlyph glyph) {
     }
 }
 
+/*
+Tells if a glyph represents part of the environment (true) or an item or creature (false).
+*/
+boolean isEnvironmentGlyph(enum displayGlyph glyph) {
+    switch (glyph) {
+        // items
+        case G_AMULET: case G_ARMOR: case G_BEDROLL: case G_CHARM:
+        case G_DEWAR: case G_EGG: case G_FOOD: case G_GEM: case G_BLOODWORT_POD:
+        case G_GOLD: case G_KEY: case G_POTION: case G_RING:
+        case G_SCROLL: case G_STAFF: case G_WAND: case G_WEAPON:
+            return false;
+
+        // creatures
+        case G_ANCIENT_SPIRIT: case G_BAT: case G_BLOAT: case G_BOG_MONSTER:
+        case G_CENTAUR: case G_CENTIPEDE: case G_DAR_BATTLEMAGE: case G_DAR_BLADEMASTER:
+        case G_DAR_PRIESTESS: case G_DEMON: case G_DRAGON: case G_EEL:
+        case G_FLAMEDANCER: case G_FURY: case G_GOBLIN: case G_GOBLIN_CHIEFTAN:
+        case G_GOBLIN_MAGIC: case G_GOLEM: case G_GUARDIAN: case G_IFRIT:
+        case G_IMP: case G_JACKAL: case G_JELLY: case G_KOBOLD:
+        case G_KRAKEN: case G_LICH: case G_MONKEY: case G_MOUND:
+        case G_NAGA: case G_OGRE: case G_OGRE_MAGIC: case G_PHANTOM:
+        case G_PHOENIX: case G_PIXIE: case G_PLAYER: case G_RAT:
+        case G_REVENANT: case G_SALAMANDER: case G_SPIDER: case G_TENTACLE_HORROR:
+        case G_TOAD: case G_TROLL: case G_UNDERWORM: case G_UNICORN:
+        case G_VAMPIRE: case G_WARDEN: case G_WINGED_GUARDIAN: case G_WISP:
+        case G_WRAITH: case G_ZOMBIE:
+            return false;
+
+        // everything else is considered part of the environment
+        default:
+            return true;
+    }
+}
 
 void plotChar(enum displayGlyph inputChar,
               short xLoc, short yLoc,
@@ -226,11 +259,11 @@ boolean takeScreenshot() {
     }
 }
 
-boolean setGraphicsEnabled(boolean state) {
-    if (currentConsole.setGraphicsEnabled) {
-        return currentConsole.setGraphicsEnabled(state);
+enum graphicsModes setGraphicsMode(enum graphicsModes mode) {
+    if (currentConsole.setGraphicsMode) {
+        return currentConsole.setGraphicsMode(mode);
     } else {
-        return false;
+        return TEXT_GRAPHICS;
     }
 }
 

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -17,7 +17,7 @@ struct keypair {
 
 static struct keypair remapping[MAX_REMAPS];
 static size_t nremaps = 0;
-static boolean showGraphics = false;
+static enum graphicsModes showGraphics = TEXT_GRAPHICS;
 
 static rogueEvent lastEvent;
 
@@ -336,7 +336,7 @@ static int fontIndex(enum displayGlyph glyph) {
     if (glyph < 128) {
         // ASCII characters map directly
         return glyph;
-    } else if (showGraphics && glyph >= 128) {
+    } else if (showGraphics == TILES_GRAPHICS || (showGraphics == HYBRID_GRAPHICS && isEnvironmentGlyph(glyph))) {
         // Tile glyphs have sprite indices starting at 256
         // -2 to disregard the up and down arrow glyphs
         return glyph + 128 - 2;
@@ -414,11 +414,11 @@ static boolean _takeScreenshot() {
 }
 
 
-static boolean _setGraphicsEnabled(boolean state) {
-    showGraphics = state;
+static enum graphicsModes _setGraphicsMode(enum graphicsModes mode) {
+    showGraphics = mode;
     refreshScreen();
     updateScreen();
-    return state;
+    return mode;
 }
 
 
@@ -431,5 +431,5 @@ struct brogueConsole sdlConsole = {
     _modifierHeld,
     NULL,
     _takeScreenshot,
-    _setGraphicsEnabled
+    _setGraphicsMode
 };


### PR DESCRIPTION
Graphics mode now has 3 possible states:

- Text: unicode only
- Tiles: tiles for everything (environment, creatures, items)
- Hybrid: tiles for environment, text for creatures and items