### PR TITLE
Only 1 gold per pile; grant score for depth

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4844,7 +4844,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 printString(buf, (20 - strLenWithoutEscapes(buf)) / 2, y++, (dim ? &darkGray : &gray), &backgroundColor, 0);
             }
             if (y < ROWS - 1 && rogue.gold) {
-                sprintf(buf, "Gold: %li", rogue.gold);
+                sprintf(buf, "Score: %li", rogue.gold);
                 buf[20] = '\0';
                 printString("                    ", 0, y, &white, &backgroundColor, 0);
                 printString(buf, (20 - strLenWithoutEscapes(buf)) / 2, y++, (dim ? &darkGray : &gray), &backgroundColor, 0);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -355,7 +355,9 @@ item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind) {
         case GOLD:
             theEntry = NULL;
             theItem->displayChar = G_GOLD;
-            theItem->quantity = rand_range(50 + rogue.depthLevel * 10, 100 + rogue.depthLevel * 15);
+            // Brogue Lite: no gold amounts fuzzing
+            theItem->quantity = GOLD_PER_PILE;
+            //theItem->quantity = rand_range(50 + rogue.depthLevel * 10, 100 + rogue.depthLevel * 15);
             break;
         case AMULET:
             theEntry = NULL;
@@ -833,7 +835,14 @@ void pickUpItemAt(short x, short y) {
         if (theItem->category & GOLD) {
             rogue.gold += theItem->quantity;
             rogue.featRecord[FEAT_TONE] = false;
+            // Brogue Lite: 1 gold per pile (defined in GOLD_PER_PILE)
+            rogue.gold += theItem->quantity;
             sprintf(buf, "you found %i pieces of gold.", theItem->quantity);
+            if (theItem->quantity > 1) {
+              sprintf(buf, "you found %i pieces of gold.", theItem->quantity);
+            } else {
+              sprintf(buf, "you found a piece of gold.", theItem->quantity);
+            }
             messageWithColor(buf, &itemMessageColor, 0);
             deleteItem(theItem);
             removeItemFrom(x, y); // triggers tiles with T_PROMOTES_ON_ITEM_PICKUP

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -164,6 +164,11 @@ typedef long long fixpt;
 #define AMULET_LEVEL            26          // how deep before the amulet appears
 #define DEEPEST_LEVEL           40          // how deep the universe goes
 
+// Brogue Lite: scoring
+#define SCORE_PER_DEPTH         1     // how many points we give on each descent
+#define GOLD_PER_PILE           1     // how many gold pieces we place in each pile (when using fixed pile sizes)
+
+
 #define MACHINES_FACTOR         FP_FACTOR   // use this to adjust machine frequency
 
 #define MACHINES_BUFFER_LENGTH  200

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -759,6 +759,10 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
     if (!levels[rogue.depthLevel-1].visited) {
         levels[rogue.depthLevel-1].visited = true;
+        // Brogue Lite: add 1 score (= gold) for each level visited (but not at game start)
+        if (rogue.depthLevel > 1) {
+        rogue.gold += SCORE_PER_DEPTH;
+        }
         if (rogue.depthLevel == AMULET_LEVEL) {
             messageWithColor("An alien energy permeates the area. The Amulet of Yendor must be nearby!", &itemMessageColor, 0);
         } else if (rogue.depthLevel == DEEPEST_LEVEL) {
@@ -1061,6 +1065,8 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         sprintf(buf, "Killed by a%s %s on depth %i", (isVowelish(killedBy) ? "n" : ""), killedBy,
                 rogue.depthLevel);
     }
+    // Brogue Lite: gold grants 1 score per piece but there is only 1 piece/score in each gold pile (defined in GOLD_PER_PILE)
+    // we also score for depth by adding gold when descending (defined in SCORE_PER_DEPTH)
     theEntry.score = rogue.gold;
     if (rogue.easyMode) {
         theEntry.score /= 10;
@@ -1169,11 +1175,14 @@ void victory(boolean superVictory) {
     printString(displayedMessage[0], mapToWindowX(0), mapToWindowY(-1), &white, &black, dbuf);
 
     plotCharToBuffer(G_GOLD, mapToWindowX(2), mapToWindowY(1), &yellow, &black, dbuf);
-    printString("Gold", mapToWindowX(4), mapToWindowY(1), &white, &black, dbuf);
+    printString("Score", mapToWindowX(4), mapToWindowY(1), &white, &black, dbuf);
     sprintf(buf, "%li", rogue.gold);
     printString(buf, mapToWindowX(60), mapToWindowY(1), &itemMessageColor, &black, dbuf);
+    // Brogue Lite: gold grants 1 score per piece but there is only 1 piece/score in each gold pile (defined in GOLD_PER_PILE)
+    // we also score for depth by adding gold when descending (defined in SCORE_PER_DEPTH)
     totalValue += rogue.gold;
 
+    // Score for lumenstones & amulet (other items' score value is checked but always 0)
     for (i = 4, theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
         if (theItem->category & GEM) {
             gemCount += theItem->quantity;


### PR DESCRIPTION
Migrated from old repository: https://github.com/HomebrewHomunculus/BrogueLite/pull/28

- All gold piles have the same score value, 1 point (TODO: or `(1+round_down(depth/7))`?)
- Depth reached gives 1 point of score per level (TODO: currently uses current depth; need to fix it for when escaping the dungeon, to actually se the max depth reached, as currently it will probably use depth 1 since that's where the exit is)