### PR TITLE
GHA: disable broken MacOS build job for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         path: BrogueLite-linux-x86_64.tar.gz
 
   macos:
+    if: ${{ false }}  # Disable broken MacOS build job for now - see issue at: https://github.com/tmewett/BrogueCE/issues/509
     runs-on: macos-latest
     steps:
     - name: "Checkout sources"


### PR DESCRIPTION
Disable the Github Actions job that fails every time, for now.

It's also broken on CE, so this isn't solely a Lite issue. Track the CE issue for a possible solution:
* https://github.com/tmewett/BrogueCE/issues/509

And this Lite issue:
* https://github.com/HomebrewHomunculus/BrogueCE/issues/17